### PR TITLE
remove references to fewestGuesses

### DIFF
--- a/src/components/guess-form.js
+++ b/src/components/guess-form.js
@@ -25,7 +25,6 @@ export class GuessForm extends React.Component {
 
 const mapStateToProps = state => ({
     guessCount: state.guesses.length,
-    fewestGuesses: state.fewestGuesses,
     correctAnswer: state.correctAnswer
 });
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -16,7 +16,6 @@ export default (state, action) => {
     if (action.type === NEW_GAME) {
         state = Object.assign({
         }, initialState, {
-            fewestGuesses: state.fewestGuesses,
             correctAnswer: action.correctAnswer
         });
         return state;


### PR DESCRIPTION
This maybe used to be a feature, but isn't anymore? These two lines certainly aren't doing anything,
and they foul up tests that check to make sure we have the expected properties in the state after
the NEW_GAME action runs.