### PR TITLE
Floor random rather than rounding it

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -7,7 +7,7 @@ import {
 const initialState = {
     guesses: [],
     feedback: 'Make your guess!',
-    correctAnswer: Math.round(Math.random() * 100),
+    correctAnswer: Math.floor(Math.random() * 100) + 1,
     showInfoModal: false
 };
 


### PR DESCRIPTION
Using round() with Math.random() skews the output away from the extremes. The safe way to use Math.random() to generate integers is with floor.

Cherry-picked from react-hot-cold#46fb1450e74e9eb28d88326dbc4fcc6d9f9a48a3